### PR TITLE
Improved naming and added new function to clarify encoder intentions

### DIFF
--- a/123_numberpad_cipher.js
+++ b/123_numberpad_cipher.js
@@ -1,32 +1,35 @@
 exports.smallEncrypt = (input) => {
-  output = ""
-  numberpad = ["1","2","3"]
-  const mod = (x, n) => (x % n + n) % n
+  var output = ""
+  var numberpad = ["1","2","3"]
+  const letWrapAround = (x) => {
+    var n = numberpad.length
+    return (x % n + n) % n
+  }
 
   var left = "1"
   var nomove = "2"
   var right = "3"
 
-  encoder = (startingPostion, endPosition) => {
-    var number = numberpad.indexOf(startingPostion);
+  encodeByMove = (startingPostion, endPosition) => {
+    var startingIndex = numberpad.indexOf(startingPostion);
 
     postionEnconder = new Map([
-      [numberpad[mod((number + 1),3)],right],
-      [numberpad[mod((number - 1),3)],left],
-      [numberpad[number],nomove]
+      [numberpad[letWrapAround(startingIndex + 1)],right],
+      [numberpad[letWrapAround(startingIndex - 1)],left],
+      [numberpad[startingIndex],nomove]
       ]);
 
     return postionEnconder.get(endPosition)
   }
 
   if (input[0]) {
-    output += encoder("1",input[0])
+    output += encodeByMove("1",input[0])
   }
 
   i = 0
   while (i < input.length - 1) {
 
-    output += encoder(input[i],input[i + 1])
+    output += encodeByMove(input[i],input[i + 1])
 
     i++
   }


### PR DESCRIPTION
A few naming improvements and new function

-Added new wrap around function to justify its necessity to the encoding
-Changed encoder name to encode by move to clarify the output we receive in relation to the defined moves
-Renamed number to starting index to highlight we are encoding based on position on numberpad

Still unsure on clarity of the wrap around function, feels ambiguous even though it is descriptive of its desired function